### PR TITLE
Allow configuration at runtime, ASCII mode

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,10 +15,11 @@ func (r *gamesCmd) Run(ctx *context) error {
 	}
 
 	fmt.Println(printGames(nowPlaying, printerConfig{
-		colorBoard:  "default",
-		colorLegend: "default",
-		colorPieces: "default",
-		showLegend:  true,
+		colorBoard:  cli.ColorBoard,
+		colorLegend: cli.ColorLegend,
+		colorPieces: cli.ColorPieces,
+		ascii:       cli.AsciiMode,
+		showLegend:  !cli.HideLegend,
 	}))
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -10,12 +10,17 @@ type context struct {
 
 var cli struct {
 	Debug         bool   `help:"Enable debug mode."`
-	LichessAPIKey string `help:"Enable debug mode."`
+	LichessAPIKey string `help:"Lichess API key"`
 
-	Games gamesCmd `cmd:"" help:"Lists all active games"`
-	G     gamesCmd `cmd:"" help:"Lists all active games"`
-	Play  playCmd  `cmd:"" help:"Play a move in a game."`
-	P     playCmd  `cmd:"" help:"Play a move in a game."`
+	AsciiMode   bool     `help:"Use Ascii characters instead of unicode chess pieces"`
+	ColorBoard  string   `help:"Color of the board. Options: default, black_and_white, blue, cyan, green, magenta, none, red, yellow" default:"default"`
+	ColorLegend string   `help:"Color of the legend. Options: none, default" default:"default"`
+	ColorPieces string   `help:"Color of the pieces. Options: default, black_and_white, none" default:"default"`
+	HideLegend  bool     `help:"Hide legend on the board"`
+	Games       gamesCmd `cmd:"" help:"Lists all active games"`
+	G           gamesCmd `cmd:"" help:"Lists all active games"`
+	Play        playCmd  `cmd:"" help:"Play a move in a game."`
+	P           playCmd  `cmd:"" help:"Play a move in a game."`
 }
 
 func main() {

--- a/printer.go
+++ b/printer.go
@@ -19,6 +19,7 @@ type printerConfig struct {
 	colorBoard  string
 	colorLegend string
 	colorPieces string
+	ascii       bool
 	showLegend  bool
 }
 
@@ -75,8 +76,23 @@ var (
 		'q': {PieceQueenBlack},
 		'r': {PieceRookBlack},
 	}
-	legendRow      = table.Row{" a ", " b ", " c ", " d ", " e ", " f ", " g ", " h "}
-	pieceStringMap = map[Piece]string{
+	legendRow           = table.Row{" a ", " b ", " c ", " d ", " e ", " f ", " g ", " h "}
+	asciiPieceStringMap = map[Piece]string{
+		PieceBishopBlack: " B ",
+		PieceBishopWhite: " B ",
+		PieceKingBlack:   " K ",
+		PieceKingWhite:   " K ",
+		PieceKnightBlack: " N ",
+		PieceKnightWhite: " N ",
+		PieceNone:        "   ",
+		PiecePawnBlack:   " P ",
+		PiecePawnWhite:   " P ",
+		PieceQueenBlack:  " Q ",
+		PieceQueenWhite:  " Q ",
+		PieceRookBlack:   " R ",
+		PieceRookWhite:   " R ",
+	}
+	unicodePieceStringMap = map[Piece]string{
 		PieceBishopBlack: " ♝ ",
 		PieceBishopWhite: " ♗ ",
 		PieceKingBlack:   " ♚ ",
@@ -130,7 +146,11 @@ func printGame(game nowPlaying, cfg printerConfig) string {
 		rowColorized := table.Row{}
 		for colIdx, col := range row {
 			cellColors := getCellColors(rowIdx, colIdx, row[colIdx], cfg)
-			rowColorized = append(rowColorized, cellColors.Sprint(pieceStringMap[col]))
+			if cfg.ascii {
+				rowColorized = append(rowColorized, cellColors.Sprint(asciiPieceStringMap[col]))
+			} else {
+				rowColorized = append(rowColorized, cellColors.Sprint(unicodePieceStringMap[col]))
+			}
 		}
 		if cfg.showLegend {
 			rowColorized = append(rowColorized, colorLegend.Sprintf(" %d ", 8-rowIdx))


### PR DESCRIPTION
Thanks for putting this together!

Noticed that some of the board configuration was hardcoded, added it to the CLI.

I also added the option to use ascii chess pieces instead of unicode pieces